### PR TITLE
Adding fail-fast=false to gh wf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   raku:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest


### PR DESCRIPTION
Esures that crashing Windows windowsworkflow is not canceling Linux or MacOS workflows.
